### PR TITLE
bumped version of lwjgl to 2.9.0

### DIFF
--- a/slick2d-core/pom.xml
+++ b/slick2d-core/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.lwjgl.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
-			<version>2.8.5</version>
+			<version>2.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.jnlp</groupId>


### PR DESCRIPTION
I updated the version of lwjgl to 2.9.0 as I was having difficultly running the sample application generated on OSX 10.8.
