### PR TITLE
Make sure game quits when using game.sh

### DIFF
--- a/slick2d-basic-game-archetype/src/main/resources/archetype-resources/src/main/scripts/game.sh
+++ b/slick2d-basic-game-archetype/src/main/resources/archetype-resources/src/main/scripts/game.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 BASE=`dirname $0`
-java -jar -Djava.library.path="$BASE/lib/" "$BASE/${project.build.finalName}.${project.packaging}" &
+java -jar -Djava.library.path="$BASE/lib/" "$BASE/${project.build.finalName}.${project.packaging}"


### PR DESCRIPTION
I noticed when using this for development, my game would not quit using the `game.sh` script. It seemed the trailing `&` was the culprit.

Unless it is used for some reason, I'd suggest to remove it. (the `game.bat` does not seem to have it)