### PR TITLE
Install fails on OS X

### DIFF
--- a/src/main/script/osx-native-name-fix.sh
+++ b/src/main/script/osx-native-name-fix.sh
@@ -1,0 +1,3 @@
+dir=slick2d-core/target/natives
+lib=liblwjgl
+ln -fs "${lib}.jnilib" "${dir}/${lib}.dylib"


### PR DESCRIPTION
I'm running into a lot of problems trying to install slick on OS X. This package requires Java 1.7, which is not the default JDK (1.6 is bundled). Moreover LWJGL seems to be incompatible with >1.7, from what I've gathered.

Which platforms are you testing this package on?
Travis has some support for OS X testing, maybe this could help?