### PR TITLE
Fix NPE when loading maps with terraintypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+* Fix NullPointerException when loading Tiled maps with terraintypes
 * Bump LWJGL to v2.9.3 to fix a build problem on Mac OS X
 * Fix Javadoc for JDK 8 thanks to cdlm
 

--- a/slick2d-core/src/main/java/org/newdawn/slick/tiled/TileSet.java
+++ b/slick2d-core/src/main/java/org/newdawn/slick/tiled/TileSet.java
@@ -136,17 +136,19 @@ public class TileSet {
 
 			Element propsElement = (Element) tileElement.getElementsByTagName(
 					"properties").item(0);
-			NodeList properties = propsElement.getElementsByTagName("property");
-			for (int p = 0; p < properties.getLength(); p++) {
-				Element propElement = (Element) properties.item(p);
+			if(propsElement != null) {
+				NodeList properties = propsElement.getElementsByTagName("property");
+				for (int p = 0; p < properties.getLength(); p++) {
+					Element propElement = (Element) properties.item(p);
 
-				String name = propElement.getAttribute("name");
-				String value = propElement.getAttribute("value");
+					String name = propElement.getAttribute("name");
+					String value = propElement.getAttribute("value");
 
-				tileProps.setProperty(name, value);
+					tileProps.setProperty(name, value);
+				}
+
+				props.put(new Integer(id), tileProps);
 			}
-
-			props.put(new Integer(id), tileProps);
 		}
 	}
 


### PR DESCRIPTION
Simple null pointer check, enable loading of Tiled maps containing terraintpyes