### PR TITLE
Fix off-by-one bug for y-position of mouse cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+* Fix off-by-one bug for y-position of mouse cursor
 * Fix NullPointerException when loading Tiled maps with terraintypes
 * Bump LWJGL to v2.9.3 to fix a build problem on Mac OS X
 * Fix Javadoc for JDK 8 thanks to cdlm

--- a/slick2d-core/src/main/java/org/newdawn/slick/Input.java
+++ b/slick2d-core/src/main/java/org/newdawn/slick/Input.java
@@ -769,7 +769,7 @@ public class Input {
 	 * @return The absolute y position of the mouse cursor
 	 */
 	public int getAbsoluteMouseY() {
-		return height - Mouse.getY();
+		return height - Mouse.getY() - 1;
 	}
 	   
 	/**
@@ -778,7 +778,7 @@ public class Input {
 	 * @return The x position of the mouse cursor
 	 */
 	public int getMouseX() {
-		return (int) ((Mouse.getX() * scaleX)+xoffset);
+		return (int) ((getAbsoluteMouseX() * scaleX)+xoffset);
 	}
 	
 	/**
@@ -787,7 +787,7 @@ public class Input {
 	 * @return The y position of the mouse cursor
 	 */
 	public int getMouseY() {
-		return (int) (((height-Mouse.getY()) * scaleY)+yoffset);
+		return (int) ((getAbsoluteMouseY() * scaleY)+yoffset);
 	}
 	
 	/**
@@ -1209,7 +1209,7 @@ public class Input {
 					mousePressed[Mouse.getEventButton()] = true;
 
 					pressedX = (int) (xoffset + (Mouse.getEventX() * scaleX));
-					pressedY =  (int) (yoffset + ((height-Mouse.getEventY()) * scaleY));
+					pressedY =  (int) (yoffset + ((height-Mouse.getEventY()-1) * scaleY));
 
 					for (int i=0;i<mouseListeners.size();i++) {
 						MouseListener listener = (MouseListener) mouseListeners.get(i);
@@ -1225,7 +1225,7 @@ public class Input {
 					mousePressed[Mouse.getEventButton()] = false;
 					
 					int releasedX = (int) (xoffset + (Mouse.getEventX() * scaleX));
-					int releasedY = (int) (yoffset + ((height-Mouse.getEventY()) * scaleY));
+					int releasedY = (int) (yoffset + ((height-Mouse.getEventY()-1) * scaleY));
 					if ((pressedX != -1) && 
 					    (pressedY != -1) &&
 						(Math.abs(pressedX - releasedX) < mouseClickTolerance) && 


### PR DESCRIPTION
Hi, it's me again. I fixed a small inaccuracy in the Input class, where the y-position of the mouse cursor at the very the top position was reported as 1, and not 0. 